### PR TITLE
Use PATCHES and drop src_prepare()

### DIFF
--- a/media-gfx/monica/monica-3.7.ebuild
+++ b/media-gfx/monica/monica-3.7.ebuild
@@ -17,15 +17,10 @@ IUSE=""
 DEPEND=">=x11-libs/fltk-1.1:1"
 RDEPEND="${DEPEND}
 	x11-apps/xgamma"
-
-src_prepare() {
-	epatch \
-		"${FILESDIR}"/${PN}-3.6-makefile-cleanup.patch \
-		"${FILESDIR}"/${P}-gcc44.patch
-	eapply_user
-
-	emake clean
-}
+PATCHES=(
+	"${FILESDIR}"/${PN}-3.6-makefile-cleanup.patch
+	"${FILESDIR}"/${P}-gcc44.patch
+)
 
 src_compile() {
 	emake \


### PR DESCRIPTION
EAPI=6 introduces the PATCHES variables which can be used instead of epatch, allowing for src_prepare()'s default implementation to be used.
